### PR TITLE
Fix all single quotes in the story name instead of only the first

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Pivotal Markdown Link",
   "description": "Adds a button to pivotal story card to copy some markdown about the story.",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "hjdarnel",
   "manifest_version": 2,
   "content_scripts": [

--- a/src/pmdl.js
+++ b/src/pmdl.js
@@ -43,7 +43,7 @@ PMDL = function() {
     return template
       .replace(/{{ID}}/, storyId(story))
       .replace(/{{URL}}/, storyUrl(story))
-      .replace(/{{NAME}}/, storyName(story).replace(/'/, "’"));
+      .replace(/{{NAME}}/, storyName(story).replace(/'/g, "’"));
   }
 
   function createMDButton(baseButton) {


### PR DESCRIPTION
Previously, only the first single quote would be replaced with a curly single quote. This caused any stories with more than one single quote in the story name to cut off the name when pasting. 

This change ensures that all single quotes in the story name are replaced to avoid any truncation of the story name.